### PR TITLE
Allow setting the attach timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,11 @@ Count time blocking on IO towards the execution totals for each function:
 ```python
 gevent_profiler.time_blocking(True)
 ```
+
+By default, there is a timeout of 60 seconds on the `attach`/`detach` methods. Change it or disable by
+passing 0 to:
+
+```python
+gevent_profiler.set_attach_duration(120)
+```
+

--- a/gevent_profiler/__init__.py
+++ b/gevent_profiler/__init__.py
@@ -290,6 +290,10 @@ def detach():
 	global _attach_expiration
 	global _trace_began_at
 
+	# do we have a current trace?
+	if not _trace_began_at:
+		return
+
 	duration = time.time() - _trace_began_at
 	_attach_expiration = None
 	sys.settrace(None)

--- a/gevent_profiler/__init__.py
+++ b/gevent_profiler/__init__.py
@@ -275,7 +275,8 @@ def attach():
 	if _attach_expiration is not None:
 		return
 	now = time.time()
-	_attach_expiration = now + _attach_duration
+	if _attach_duration != 0:
+		_attach_expiration = now + _attach_duration
 	_trace_began_at = now
 	sys.settrace(_globaltrace)
 
@@ -356,6 +357,15 @@ def time_blocking(enabled=True):
 	"""
 	global _time_blocking
 	_time_blocking = enabled
+
+def set_attach_duration(attach_duration=60):
+	"""
+	Set the duration that attach/detach are allowed to operate for.
+	Will automatically detach after that time if any profile call is made.
+	By default this time period is 60 seconds. Set to 0 to disable.
+	"""
+	global _attach_duration
+	_attach_duration = attach_duration
 
 def _sighandler(signum, frame):
 	attach()


### PR DESCRIPTION
I ran into some problems while trying to profile long-running operations - whenever my code eventually got to the `detach` method, it would just throw a python error.  Tracing the steps, I figured it out there is a timeout involved, by default set to 60 seconds.

This patch does a few things:
- Makes it so calling `detach` when there isn't an active `attach` session is not an error
- Allows you to configure or disable the timeout by calling `set_attach_duration` - set to `0` to disable.
